### PR TITLE
New format for x-filterable-fields

### DIFF
--- a/schemas/SchemaObject.schema.json
+++ b/schemas/SchemaObject.schema.json
@@ -91,6 +91,28 @@
           ]
         }
       }
+    },
+    "x-filterable-fields": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "operators"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "operators": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/commands/print/apiStatus.js
+++ b/src/commands/print/apiStatus.js
@@ -1,5 +1,5 @@
 const yamlJs = require('yamljs');
-const { buildOperationMap, generateReadMeDataBlock } = require('../../util');
+const { buildOperationMap } = require('../../util');
 
 /**
  * Print the API status for all paths matching the tag.

--- a/src/commands/print/definition.js
+++ b/src/commands/print/definition.js
@@ -7,6 +7,7 @@ const {
   generateReadMeTable,
   buildOperationMap,
   backtick,
+  capitalise,
 } = require('../../util');
 
 /** Definitions that don't go in See Also **/
@@ -110,10 +111,10 @@ const generateDefinitionText = async (spec, schemaName, exampleSummary) => {
     const headers = ['Field', 'Type', 'Operators'];
     const rows = filterableFields.reduce((res, item) => {
       const operators = item.operators.map(backtick).join(', ');
-      res.push([backtick(item.name), item.type, operators]);
+      res.push([backtick(item.name), capitalise(item.type), operators]);
       return res;
     }, []);
-    output += '\n\n### Filterable Fields\n';
+    output += '\n\n### Filterable Fields\n\nThis resource type can be filtered using the following fields and operators.\n';
     output += generateReadMeTable(headers, rows);
   }
 

--- a/src/commands/print/definition.js
+++ b/src/commands/print/definition.js
@@ -2,7 +2,7 @@ const refParser = require('json-schema-ref-parser');
 const yamlJs = require('yamljs');
 const { generateFieldsText } = require('./fields');
 const { generateSchemaText } = require('./schema');
-const { generateReadMeDataBlock, buildOperationMap } = require('../../util');
+const { generateReadMeWidget, generateReadMeTable, buildOperationMap } = require('../../util');
 
 /** Definitions that don't go in See Also **/
 const SEE_ALSO_EXCEPTIONS = ['CustomFieldsDocument', 'IdentifiersDocument', 'TagsDocument'];
@@ -73,7 +73,7 @@ const generateDefinitionText = async (spec, schemaName, exampleSummary) => {
   output += `${derefSpec.components.schemas[schemaName].description}\n`;
 
   // Three tab widget with Fields, Schema, and Example
-  output += generateReadMeDataBlock({
+  output += generateReadMeWidget('code', {
     codes: [{
       name: 'Fields',
       language: 'text',
@@ -97,6 +97,19 @@ const generateDefinitionText = async (spec, schemaName, exampleSummary) => {
     const linkTags = seeAlsoMap
       .map(defName => '[`' + defName + '`](#section-' + defName.toLowerCase() + '-data-model)');
     output += linkTags.join(', ');
+  }
+
+  // Filterable fields table
+  const filterableFields = derefSpec.components.schemas[schemaName]['x-filterable-fields'];
+  if (filterableFields) {
+    const headers = ['Field', 'Type', 'Operators'];
+    const rows = filterableFields.reduce((res, item) => {
+      const operators = item.operators.map(p => '`' + p + '`').join(', ');
+      res.push([item.name, item.type, operators]);
+      return res;
+    }, []);
+    output += '\n\n### Filterable Fields\n';
+    output += generateReadMeTable(headers, rows);
   }
 
   return output + '\n___\n\n';

--- a/src/commands/print/definition.js
+++ b/src/commands/print/definition.js
@@ -2,7 +2,12 @@ const refParser = require('json-schema-ref-parser');
 const yamlJs = require('yamljs');
 const { generateFieldsText } = require('./fields');
 const { generateSchemaText } = require('./schema');
-const { generateReadMeWidget, generateReadMeTable, buildOperationMap } = require('../../util');
+const {
+  generateReadMeWidget,
+  generateReadMeTable,
+  buildOperationMap,
+  backtick,
+} = require('../../util');
 
 /** Definitions that don't go in See Also **/
 const SEE_ALSO_EXCEPTIONS = ['CustomFieldsDocument', 'IdentifiersDocument', 'TagsDocument'];
@@ -104,8 +109,8 @@ const generateDefinitionText = async (spec, schemaName, exampleSummary) => {
   if (filterableFields) {
     const headers = ['Field', 'Type', 'Operators'];
     const rows = filterableFields.reduce((res, item) => {
-      const operators = item.operators.map(p => '`' + p + '`').join(', ');
-      res.push([item.name, item.type, operators]);
+      const operators = item.operators.map(backtick).join(', ');
+      res.push([backtick(item.name), item.type, operators]);
       return res;
     }, []);
     output += '\n\n### Filterable Fields\n';

--- a/src/commands/print/operation.js
+++ b/src/commands/print/operation.js
@@ -1,5 +1,5 @@
 const yamlJs = require('yamljs');
-const { buildOperationMap, generateReadMeDataBlock } = require('../../util');
+const { buildOperationMap, generateReadMeWidget } = require('../../util');
 
 /**
  * Print the operation's summary as a preamble.
@@ -258,7 +258,7 @@ const generateResponseSnippet = (data) => {
  * @param {object} data - Data about the operation.
  * @returns {string} Formatted request snippet in multiple languages.
  */
-const generateRequest = data => generateReadMeDataBlock({
+const generateRequest = data => generateReadMeWidget('code', {
   codes: [{
     language: 'http',
     code: generateHttpSnippet(data),
@@ -278,7 +278,7 @@ const generateRequest = data => generateReadMeDataBlock({
  * @param {object} data - Data about the operation.
  * @returns {string} Formatted response snippets.
  */
-const generateResponse = data => generateReadMeDataBlock({
+const generateResponse = data => generateReadMeWidget('code', {
   codes: [{
     language: 'http',
     code: generateResponseSnippet(data),

--- a/src/util.js
+++ b/src/util.js
@@ -102,7 +102,6 @@ const generateReadMeTable = (headers, rows) => {
       table.data[`${rowIndex}-${colIndex}`] = cell;
     });
   });
-  console.log(JSON.stringify(table, null, 2));
 
   return generateReadMeWidget('parameters', table);
 };

--- a/src/util.js
+++ b/src/util.js
@@ -70,11 +70,42 @@ const expand = (spec, target) => {
 /**
  * Generate a ReadMe.io format data block.
  *
+ * @param {string} type - ReadMe specific block type ('code' for syntax block, 'parameters' for table)
  * @param {object} readMeData - ReadMe format JSON data.
  * @returns {string} The ReadMe.io data block.
  */
-const generateReadMeDataBlock = readMeData =>
-  `[block:code]\n${JSON.stringify(readMeData, null, 2)}\n[/block]`;
+const generateReadMeWidget = (type, readMeData) =>
+  `[block:${type}]\n${JSON.stringify(readMeData, null, 2)}\n[/block]`;
+
+/**
+ * Generate a ReadMe.io format table widget from rows of data.
+ *
+ * @param {string[]} headers - Table headers.
+ * @param {[][]} rows - Array of arrays, each containing row values.
+ * @returns {string} The ReadMe.io table widget string.
+ */
+const generateReadMeTable = (headers, rows) => {
+  const table = {
+    data: {},
+    cols: headers.length,
+    rows: rows.length,
+  };
+
+  // Add the headers
+  headers.forEach((header, i) => {
+    table.data[`h-${i}`] = header;
+  });
+
+  // Add the data
+  rows.forEach((row, rowIndex) => {
+    row.forEach((cell, colIndex) => {
+      table.data[`${rowIndex}-${colIndex}`] = cell;
+    });
+  });
+  console.log(JSON.stringify(table, null, 2));
+
+  return generateReadMeWidget('parameters', table);
+};
 
 /**
  * Build a map of operations to their path and method.
@@ -156,7 +187,8 @@ const askForOrderedList = async (items, prompt) => {
 
 module.exports = {
   expand,
-  generateReadMeDataBlock,
+  generateReadMeWidget,
+  generateReadMeTable,
   lintWithSchema,
   buildOperationMap,
   getValue,

--- a/src/util.js
+++ b/src/util.js
@@ -184,6 +184,14 @@ const askForOrderedList = async (items, prompt) => {
   return ordered;
 };
 
+/**
+ * Surround a string in backticks.
+ *
+ * @param {string} str - String to surround in backticks.
+ * @param {string} String surrounded by backtick.
+ */
+const backtick = str => '`' + str + '`';
+
 module.exports = {
   expand,
   generateReadMeWidget,
@@ -192,4 +200,5 @@ module.exports = {
   buildOperationMap,
   getValue,
   askForOrderedList,
+  backtick,
 };

--- a/src/util.js
+++ b/src/util.js
@@ -192,6 +192,14 @@ const askForOrderedList = async (items, prompt) => {
  */
 const backtick = str => '`' + str + '`';
 
+/**
+ * Capitalise a string.
+ *
+ * @param {string} str - String to capitalise.
+ * @param {string} Capitalised string.
+ */
+const capitalise = str => str.charAt(0).toUpperCase() + str.slice(1);
+
 module.exports = {
   expand,
   generateReadMeWidget,
@@ -201,4 +209,5 @@ module.exports = {
   getValue,
   askForOrderedList,
   backtick,
+  capitalise,
 };


### PR DESCRIPTION
Instead of a list of strings, use an object format: `{ name, type, operators }`

- [x] Update schema
- [x] Update snippet generation for `definition`